### PR TITLE
changes the file name of the temp project file from a Guid to the .csproj's file name.

### DIFF
--- a/EditProj/EditProjPackage.cs
+++ b/EditProj/EditProjPackage.cs
@@ -82,7 +82,7 @@ namespace rdomunozcom.EditProj
                         this.tempToProjFiles.Remove(tempProjFilePath);
                     }
 
-                    tempProjFilePath = GetNewTempFilePath();
+                    tempProjFilePath = GetNewTempFilePath(projFilePath);
                     this.tempToProjFiles[tempProjFilePath] = projFilePath;
                 }
 
@@ -124,10 +124,10 @@ namespace rdomunozcom.EditProj
             return projFilePath;
         }
 
-        private static string GetNewTempFilePath()
+        private static string GetNewTempFilePath(string projFilePath)
         {
             string tempDir = Path.GetTempPath();
-            string tempProjFile = Guid.NewGuid().ToString() + ".xml";
+            string tempProjFile = Path.GetFileName(projFilePath) + ".xml";
             string tempProjFilePath = Path.Combine(tempDir, tempProjFile);
             return tempProjFilePath;
         }


### PR DESCRIPTION
A simple change to make the tab title more useful.

Its also very helpful when editing multiple project files.

Issue #8 
