### PR TITLE
Fix for encoding changes during editing of project file

### DIFF
--- a/EditProj/EditProjPackage.cs
+++ b/EditProj/EditProjPackage.cs
@@ -134,8 +134,8 @@ namespace rdomunozcom.EditProj
 
         private static void CreateTempFileWithContentsOf(string sourcePath, string destPath)
         {
-            string projectData = File.ReadAllText(sourcePath);
-            File.WriteAllText(destPath, projectData);
+            byte[] projectData = File.ReadAllBytes(sourcePath);
+            File.WriteAllBytes(destPath, projectData);
         }
 
         private bool TempFileExists(string projFilePath, out string tempProjFile)
@@ -199,7 +199,7 @@ namespace rdomunozcom.EditProj
 
         private void UpdateProjFile(string tempFilePath)
         {
-            string contents = ReadFile(tempFilePath);
+            byte[] contents = ReadFile(tempFilePath);
             string projFile = this.tempToProjFiles[tempFilePath];
             if (CanEditFile(this.tempToProjFiles[tempFilePath]))
             {
@@ -217,14 +217,14 @@ namespace rdomunozcom.EditProj
             hr = queryEditQuerySave.QuerySaveFile(filePath, 0, null, out result);
         }
 
-        private static void SetFileContents(string filePath, string content)
+        private static void SetFileContents(string filePath, byte[] content)
         {
-            File.WriteAllText(filePath, content);
+            File.WriteAllBytes(filePath, content);
         }
 
-        private static string ReadFile(string filePath)
+        private static byte[] ReadFile(string filePath)
         {
-            return File.ReadAllText(filePath);
+            return File.ReadAllBytes(filePath);
         }
 
         private bool CanEditFile(string filePath)


### PR DESCRIPTION
Work with bytes so as to not modify the current encoding of the file.
